### PR TITLE
Fixed error when opening virtual ports in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Electron-based Virtual MIDI Controller that like [Novation Launchpad](https://us
 ![screen shot](./assets/screenshot.png)
 
 ## Installation
+Use Node v10.\*, Python 2.7.\*, and Visual Studio 2017 to build this project. Recent versions are not supported by some modules in this project.
 
 ```
 $ git clone https://github.com/mohayonao/virtual-midi-matrix-pad.git

--- a/src/app/midi/MIDIDevice.js
+++ b/src/app/midi/MIDIDevice.js
@@ -1,6 +1,8 @@
 import midi from "midi";
 import * as operations from "./operations";
 
+const os = require('os');
+
 export default class MIDIDevice {
   constructor(deviceName, actions) {
     this.deviceName = deviceName;
@@ -11,16 +13,55 @@ export default class MIDIDevice {
 
   open() {
     this::operations.willMIDIPortOpen();
-    if (this.midiInput === null) {
+    if(os.platform() === 'win32') {
+      console.log("Windows system: Please create virtual port 'Launchpad MK2' with LoopMIDI");
       this.midiInput = new midi.input();
-      this.midiInput.openVirtualPort(this.deviceName);
-      this.midiInput.on("message", (_, data) => {
-        this::operations.recvMessage(data, this.actions);
-      });
-    }
-    if (this.midiOutput === null) {
       this.midiOutput = new midi.output();
-      this.midiOutput.openVirtualPort(this.deviceName);
+      let inputPortIndex = -1;
+      let outputPortIndex = -1;
+
+      // Find loopMIDI virtual input and output ports
+      for (let i = 0; i < this.midiInput.getPortCount(); i++) {
+        if (this.midiInput.getPortName(i).includes(this.deviceName)) {
+          inputPortIndex = i;
+          break;
+        }
+      }
+
+      for (let i = 0; i < this.midiOutput.getPortCount(); i++) {
+        if (this.midiOutput.getPortName(i).includes(this.deviceName)) {
+          outputPortIndex = i;
+          break;
+        }
+      }
+
+      // Trying open input and output ports
+      if (inputPortIndex !== -1) {
+        this.midiInput.openPort(inputPortIndex);
+        this.midiInput.on('message', (_, data) => {
+          this::operations.recvMessage(data, this.actions);
+        });
+      } else {
+        console.error(`Input port ${this.deviceName} not found.`);
+      }
+
+      if (outputPortIndex !== -1) {
+        this.midiOutput.openPort(outputPortIndex);
+      } else {
+        console.error(`Output port ${this.deviceName} not found.`);
+      }
+    } else {
+      if (this.midiInput === null) {
+        this.midiInput = new midi.input();
+        this.midiInput.openVirtualPort(this.deviceName);
+        this.midiInput.on("message", (_, data) => {
+          this::operations.recvMessage(data, this.actions);
+        });
+      }
+      if (this.midiOutput === null) {
+        this.midiOutput = new midi.output();
+        this.midiOutput.openVirtualPort(this.deviceName);
+      }
     }
     this::operations.didMIDIPortOpen();
   }


### PR DESCRIPTION
Use the LoopMIDI program to create virtual ports in Windows. When creating the virtual port in LoopMIDI, the exact name "Launchpad MK2" must be used. After that, launch the app normally and everything will be working normally.
![image](https://github.com/user-attachments/assets/7e539175-2703-472f-9bc0-bcd9f511933a)
